### PR TITLE
同步 PHP 版本样式

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,6 @@ app.get('/', async (req, res) => {
         <RowDefinition Height="Auto" />
         <RowDefinition Height="Auto" />
         <RowDefinition Height="Auto" />
-        <RowDefinition Height="35" />
     </Grid.RowDefinitions>
 
     <local:MyCard Title="OpenBMCLAPI DashBoard on PCL2" Margin="0,0,0,5" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
@@ -75,21 +74,22 @@ app.get('/', async (req, res) => {
         </StackPanel>
     </local:MyCard>
 
-    <local:MyCard Title="主控负载" Margin="0,0,0,4" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
+     <local:MyCard Title="主控负载" Margin="0,0,0,4" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2">
         <StackPanel Margin="25,40,23,15">
-            <TextBlock Margin="0,0,0,4" HorizontalAlignment="Center" TextWrapping="Wrap">
-                <Run Text="${load}" FontSize="26"/>
-                %
-            </TextBlock>
-            <TextBlock Margin="0,0,0,4" HorizontalAlignment="Center" TextWrapping="Wrap">
-                （此处数据超过 100% 是正常现象）
-            </TextBlock>
+            <StackPanel Margin="0,0,0,4">
+                <TextBlock Margin="0,0,0,4" HorizontalAlignment="Center" TextWrapping="Wrap">
+                    <Run Text="${load}" FontSize="26"/> %
+                </TextBlock>
+                <TextBlock Margin="0,0,0,4" HorizontalAlignment="Center" TextWrapping="Wrap">
+                    （此处数据超过 100% 是正常现象）
+                </TextBlock>
+            </StackPanel>
+            <StackPanel Margin="0,4,0,0" Orientation="Horizontal" HorizontalAlignment="Center">
+                <local:MyButton Margin="0,0,4,0" Width="180" Height="35" Text="刷新" EventType="刷新主页" ToolTip="重新加载数据，请勿频繁点击" />
+                <local:MyButton Margin="4,0,0,0" Width="180" Height="35" ColorType="Highlight" Text="查看赞助商信息" EventType="打开网页" EventData="${sponsorUrl}" ToolTip="查看来自 OpenBMCLAPI 赞助商的广告" />
+            </StackPanel>
         </StackPanel>
     </local:MyCard>
-
-    <local:MyButton Margin="2,0,0,0" Grid.Row="4" Grid.Column="1" ColorType="Highlight" Text="查看赞助商信息" EventType="打开网页" EventData="${sponsorUrl}" ToolTip="查看来自 OpenBMCLAPI 赞助商的广告"/>
-
-    <local:MyButton Margin="0,0,2,0" Grid.Row="4" Grid.Column="0" Text="刷新" EventType="刷新主页" ToolTip="重新加载数据，请勿频繁点击"/>
 </Grid>
     `;
 

--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ app.get('/', async (req, res) => {
         <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
 
-    <local:MyCard Title="OpenBMCLAPI DashBoard on PCL2" Margin="0,0,0,5" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
+    <local:MyCard Title="OpenBMCLAPI DashBoard on PCL" Margin="0,0,0,5" Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
         <TextBlock Margin="25,12,20,10" HorizontalAlignment="Right">
             ${genTime} (UTC+8)
         </TextBlock>


### PR DESCRIPTION
将控制按钮收入主控状态卡片 & 用 `for PCL` 代替 `on PCL2`

---

我打算让龙猫用你的，但还有几个问题，我不确定你怎么看我就没改：

1. 感觉标题栏有点长了，直接把`on PCL2`去掉可能好点？
![](https://github.com/user-attachments/assets/65b46c6e-b125-45c4-b21d-dd2f906def76)

2. 我一开始把右栏加大是因为极端情况下右栏数据可能会溢出，而且左边数据比较短显得太空，你要是觉得就这样没问题的话那就这样也没事。

3. `Content-Type` 标头对 PCL 来说是不必要的，我之前写 `text/plain` 是因为 `application/xml` 在浏览器上会报错不渲染，如果不写的话我的本地服务器会变成 `application/octet-stream` 浏览器看不了。我不知道 SCF 不填 `Content-Type` 会不会有事，但是现在 
SCF 会自动加 `Content-Disposition: attachment` 头，所以浏览器直接访问会作为附件下载，所以不需要考虑浏览器可读性。

4. 我在考虑用我的域名跳到你的云函数上。如果你不打算考虑（打算继续用自己的域名）的话，那可以在 Cloudflare 上把 `/version` 重定向到一个无效的地址（比如 `//` ），这样可以节约一些时间和计算量。涉及到一些 PCL 的机制。